### PR TITLE
Fix mapper error throwing exception every time Map is invoked

### DIFF
--- a/SIMS/App.cs
+++ b/SIMS/App.cs
@@ -1,12 +1,18 @@
 using AutoMapper;
 using Microsoft.Extensions.DependencyInjection;
 using SIMS;
+using SIMS.Dtos;
 using SIMS.Inventories;
+using SIMS.Models;
 using SIMS.Repositories;
 
 var serviceProvider = new ServiceCollection()
   .AddScoped<IProductRepository, InMemoryProductRepository>()
-  .AddScoped<IMapper>(_ => new MapperConfiguration(_ => { }).CreateMapper())
+  .AddScoped<IMapper>(_ => new MapperConfiguration(cfg =>
+  {
+    cfg.CreateMap<Product, ProductDto>();
+    cfg.CreateMap<ProductDto, Product>();
+  }).CreateMapper())
   .AddScoped<IInventory, Inventory>()
   .AddScoped<InventoryManagementSystem>();
 


### PR DESCRIPTION
The error was present because mapper settings was not set. Settings was set in this commit.